### PR TITLE
Add regular expression to catch conda environment not found

### DIFF
--- a/jsom/__init__.py
+++ b/jsom/__init__.py
@@ -68,8 +68,8 @@ def connect_somhpc(address, username, pkey_file):
 
 def activate_conda(ssh, conda_env):
     ssh.sendline(f"conda activate {conda_env}")
-    match = ssh.expect([ssh.PROMPT, "Could not find conda environment:"])
-    if match == 1:
+    match = ssh.expect([ssh.PROMPT, "Could not find conda environment:", "Not a conda environment:"])
+    if match > 0 :
         raise Exception(f"Conda environment {conda_env} does not exist")
 
     ssh.sendline("jupyter")


### PR DESCRIPTION
Hot fix for capturing what I'm getting from the prompt when trying to activate a non-existing conda environment.